### PR TITLE
Add missing foreign key declarations for roles

### DIFF
--- a/db/migrate/20140322161444_add_foreign_keys_for_roles_and_member_roles.rb
+++ b/db/migrate/20140322161444_add_foreign_keys_for_roles_and_member_roles.rb
@@ -1,0 +1,13 @@
+class AddForeignKeysForRolesAndMemberRoles < ActiveRecord::Migration
+  def up
+    add_foreign_key :roles, :roles
+    add_foreign_key :roles, :groups
+    add_foreign_key :members_roles, :roles
+  end
+
+  def down
+    remove_foreign_key :roles, :roles
+    remove_foreign_key :roles, :groups
+    remove_foreign_key :members_roles, :roles
+  end
+end

--- a/lib/samfundet_auth/version.rb
+++ b/lib/samfundet_auth/version.rb
@@ -1,3 +1,3 @@
 module SamfundetAuth
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/samfundet_auth.gemspec
+++ b/samfundet_auth.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 3.2.8"
   s.add_dependency "declarative_authorization"
+  s.add_dependency "foreigner"
 end


### PR DESCRIPTION
This branch adds an migration containing foreign key constraints for the roles and member roles tables.
