### PR TITLE
Ensure valid Member models in production.

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -6,9 +6,14 @@ class Member < ActiveRecord::Base
 
   attr_accessor :passord if %w(production staging).include? Rails.env
 
-  attr_accessible :fornavn, :etternavn, :mail, :telefon, :passord
+  attr_accessible :fornavn, :etternavn, :mail, :telefon
 
-  validates_presence_of :fornavn, :etternavn, :mail, :telefon, :passord
+  validates_presence_of :fornavn, :etternavn, :mail, :telefon
+
+  if Rails.env.development?
+    attr_accessible :passord
+    validates_presence_of :passord
+  end
 
   def firstname
     fornavn

--- a/lib/samfundet_auth/version.rb
+++ b/lib/samfundet_auth/version.rb
@@ -1,3 +1,3 @@
 module SamfundetAuth
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
When i was debugging why LogEntries would not save, it turned out
that LogEntries was validating its associated models (the Member model,
amongst others). In production, the 'passord' field would allways be
nil, as this is something that only exists in development.

By making this validation conditional on development, the validation
should return true in production. In the future, it might be worth to
unify the production and development Member models.
